### PR TITLE
Qubino ZMNHHDx Mini Dimmer: Fix config option 65 (#29)

### DIFF
--- a/config/qubino/ZMNHHDx.xml
+++ b/config/qubino/ZMNHHDx.xml
@@ -64,10 +64,10 @@
             <Help>2 - 99 = 2% - 99%, step is 1%. Maximum dimming values is set by entered value.
                 Default value 99 (Maximum dimming value is 99%).</Help>
         </Value>
-        <Value genre="config" index="65" instance="1" label="Dimming time (soft on/off)" max="255" min="1" type="short" value="100">
-            <Help>Set value means time of moving the Dimmer between min. and max. dimming values by short press of push button I1 or controlled through.
-                1- 255 = 10mseconds - 2550mseconds (2,55s), step is 10mseconds.
-                Default value 100 (Dimming time between min. and max. dimming values is 1s).</Help>
+        <Value genre="config" index="65" instance="1" label="Dimming time (soft on/off)" max="127" min="1" type="byte" value="1">
+            <Help>Set value means time of moving the Dimmer between min. and max. dimming values by short press of push button I1 or controlled through the controller.
+                1 - 127 = 1 second - 127 seconds.
+                Default value 1 (Dimming time between min. and max. dimming values is 1s).</Help>
         </Value>
         <Value genre="config" index="66" instance="1" label="Dimming time when key hold" max="255" min="1" type="short" value="3">
             <Help>


### PR DESCRIPTION
Adjustments according to the manual [1] on parameter 65:

* The type is "1 byte dec" corresponding with "byte" in OZW, but was
  "short", so the device ignored the setting.
* The maximum value is 127, not 255.
* The default value is 1, not 100.
* The description about the valid value range appears untrue (1-255) as
  well as a 10-ms step per value.

[1]: https://qubino.com/wp-content/uploads/2019/09/Qubino_Mini-Dimmer-PLUS-extended-manual_eng_3.4_09092019.pdf